### PR TITLE
Add vibrations

### DIFF
--- a/src/main/java/com/team1678/frc2024/controlboard/ControlBoard.java
+++ b/src/main/java/com/team1678/frc2024/controlboard/ControlBoard.java
@@ -3,6 +3,7 @@ package com.team1678.frc2024.controlboard;
 import com.team1678.frc2024.Constants;
 import com.team1678.frc2024.subsystems.Drive;
 import com.team1678.lib.Util;
+import com.team1678.lib.requests.Request;
 import com.team254.lib.geometry.Rotation2d;
 import com.team254.lib.geometry.Translation2d;
 import edu.wpi.first.wpilibj.XboxController.Axis;
@@ -113,5 +114,21 @@ public class ControlBoard {
 
 	public boolean getExitClimbModeOperator() {
 		return operator.getBackButton() && operator.getStartButton();
+	}
+
+	// Rumbles both controllers as a Request, useful for sequences.
+	public Request rumbleControllers(double rumblesPerSecond, double numberOfSeconds) {
+		return new Request() {
+			@Override
+			public void act() {
+				mInstance.driver.rumble(rumblesPerSecond, numberOfSeconds);
+				mInstance.operator.rumble(rumblesPerSecond, numberOfSeconds);
+			}
+
+			@Override
+			public boolean isFinished() {
+				return true;
+			}
+		};
 	}
 }

--- a/src/main/java/com/team1678/frc2024/controlboard/DriverControls.java
+++ b/src/main/java/com/team1678/frc2024/controlboard/DriverControls.java
@@ -36,6 +36,9 @@ public class DriverControls {
 		if (!mClimbMode) {
 			mSuperstructure.setWantClimbMode(false);
 			if (mControlBoard.getEnterClimbModeDriver()) {
+				// Vibrate both controllers so the driver is sure
+				mControlBoard.rumbleControllers(90.72, 1).act();
+
 				mClimbMode = true;
 				top_buttons_clear = false;
 				mSuperstructure.tuckState();
@@ -151,6 +154,8 @@ public class DriverControls {
 
 			if (mControlBoard.getExitClimbModeDriver()) {
 				mClimbMode = false;
+				// Vibrate both controllers so the driver is sure
+				mControlBoard.rumbleControllers(90.72, 1).act();
 				return;
 			}
 

--- a/src/main/java/com/team1678/frc2024/controlboard/DriverControls.java
+++ b/src/main/java/com/team1678/frc2024/controlboard/DriverControls.java
@@ -53,7 +53,11 @@ public class DriverControls {
 			if (mControlBoard.driver.rightTrigger.isBeingPressed()) {
 				mDrive.overrideHeading(true);
 			} else {
-				mDrive.overrideHeading(false);
+				if (mControlBoard.operator.leftTrigger.isBeingPressed()) {
+					mDrive.overrideHeading(true);
+				} else {
+					mDrive.overrideHeading(false);
+				}
 			}
 
 			// Intake
@@ -97,6 +101,15 @@ public class DriverControls {
 				}
 			}
 
+			if (mControlBoard.operator.rightBumper.wasActivated()) {
+				if (mControlBoard.operator.POV270.buttonActive
+						|| IntakeDeploy.getInstance().getSetpoint() < IntakeDeploy.kUnjamAngle) {
+					mSuperstructure.slowContinuousShotState();
+				} else {
+					mSuperstructure.fireState();
+				}
+			}
+
 			if (mControlBoard.driver.POV180.wasActivated()) {
 				mSuperstructure.toggleFerry();
 			}
@@ -133,15 +146,14 @@ public class DriverControls {
 				mSuperstructure.ampUnjam();
 			}
 
-			if (mControlBoard.operator.leftBumper.longPressed()) {
-				VisionDeviceManager.setDisableVision(!VisionDeviceManager.visionDisabled());
-			}
-
 			if (mControlBoard.operator.aButton.longPressed()) {
 				System.out.println("Homing Hood!");
 				mHood.setWantHome(true);
 			}
 
+			if (mControlBoard.operator.getLeftBumperPressed()) {
+				VisionDeviceManager.setDisableVision(!VisionDeviceManager.visionDisabled());
+			}
 		} else {
 			mSuperstructure.setWantClimbMode(true);
 			if (!top_buttons_clear) {

--- a/src/main/java/com/team1678/frc2024/subsystems/Superstructure.java
+++ b/src/main/java/com/team1678/frc2024/subsystems/Superstructure.java
@@ -5,6 +5,7 @@ import com.team1678.frc2024.FieldLayout;
 import com.team1678.frc2024.Ports;
 import com.team1678.frc2024.Robot;
 import com.team1678.frc2024.RobotState;
+import com.team1678.frc2024.controlboard.ControlBoard;
 import com.team1678.frc2024.led.TimedLEDState;
 import com.team1678.frc2024.loops.ILooper;
 import com.team1678.frc2024.loops.Loop;
@@ -55,6 +56,7 @@ public class Superstructure extends Subsystem {
 	private final AmpRollers mAmpRollers = AmpRollers.getInstance();
 	private final Shooter mShooter = Shooter.getInstance();
 	private final Hood mHood = Hood.getInstance();
+	private final ControlBoard mControlBoard = ControlBoard.getInstance();
 
 	// LEDs
 	private final LEDs mLEDs = LEDs.getInstance();
@@ -523,6 +525,7 @@ public class Superstructure extends Subsystem {
 			new ParallelRequest(
 				new SequentialRequest(
 					breakWait(mFeederBreak, true, 0.0),
+					mControlBoard.rumbleControllers(90.72, 1),
 					mIntakeRollers.stateRequest(IntakeRollers.State.EXHAUST),
 					mIntakeDeploy.clearRequest(),
 					new WaitRequest(0.5),


### PR DESCRIPTION
## Description

This PR is best categorized by the following descriptors:

- [ ] Bugfix
- [ ] Refactor
- [x] New Feature
- [x] Testing
- [ ] Cleanup/Documentation

### Context

Drive team requested controller vibrations for the climb and intaking modes. The `add-vibrations` branch does that with untested, but safe to test, code.

### What Has Changed?

Adds a 1-second rumble for when climb mode is entered/exited and when a note is intaked.

## Checklists

### Testing

- [ ] This PR has been tested/verified during a meeting with no issues found.
- [ ] This PR has been tested/verified during driver practice with no issues found.
- [ ] This PR has been tested/verified at competition with no issues found.

### Formatting

- [x] This PR passes auto-formatting checks.
- [ ] The code introduced in this PR is self-documenting through reasonable variable and function names.

---
- [ ] This PR is ready to merge. Sufficient reasoning has been given for any
points left unchecked above.